### PR TITLE
[#31] login - 테스트실패 수정 및 refresh_token 활성화

### DIFF
--- a/authentication/src/main/kotlin/com/sns/authentication/LoginUser.kt
+++ b/authentication/src/main/kotlin/com/sns/authentication/LoginUser.kt
@@ -12,7 +12,7 @@ class LoginUser(
     private val password: String
 ) : UserDetails {
     override fun getAuthorities(): MutableCollection<out GrantedAuthority> = mutableListOf<GrantedAuthority>(Role.USER.createSimpleGrantedAuthority())
-    override fun getUsername(): String = name
+    override fun getUsername(): String = id
     override fun getPassword(): String = password
     override fun isAccountNonExpired(): Boolean = true
     override fun isAccountNonLocked(): Boolean = true

--- a/authentication/src/main/kotlin/com/sns/authentication/LoginUserService.kt
+++ b/authentication/src/main/kotlin/com/sns/authentication/LoginUserService.kt
@@ -9,6 +9,9 @@ import org.springframework.stereotype.Service
 class LoginUserService(
     private val userCrudRepository: UserCrudRepository
 ) : UserDetailsService {
+    /**
+     * @param username spring oauth2에서 의미하는 userName = user.id (unique key)
+     */
     override fun loadUserByUsername(username: String?): LoginUser {
         if (username.isNullOrEmpty()) throw UsernameNotFoundException("유저 정보를 찾을 수 없습니다")
         return LoginUser.create(userCrudRepository.findById(username).orElse(null))

--- a/authentication/src/main/kotlin/com/sns/authentication/LoginUserTokenEnhancer.kt
+++ b/authentication/src/main/kotlin/com/sns/authentication/LoginUserTokenEnhancer.kt
@@ -18,6 +18,7 @@ class LoginUserTokenEnhancer : TokenEnhancer {
         if (accessToken is DefaultOAuth2AccessToken) {
             val additionalInfo = mutableMapOf<String, Any>()
             additionalInfo["user_id"] = user.id
+            additionalInfo["user_nickname"] = user.name
             accessToken.additionalInformation = additionalInfo
         }
         return accessToken

--- a/authentication/src/main/kotlin/com/sns/authentication/config/OAuth2Config.kt
+++ b/authentication/src/main/kotlin/com/sns/authentication/config/OAuth2Config.kt
@@ -42,10 +42,10 @@ class OAuth2Config(
                 "http://local-front.ddd.sns.com:10100/login/oauth2/code/auth_server",
                 "http://local-front.ddd.sns.com:10100/home",
             )  // default redirect
-            ?.authorizedGrantTypes("authorization_code")
+            ?.authorizedGrantTypes("authorization_code", "refresh_token")
             ?.scopes("read")
             ?.autoApprove(true)
-            ?.accessTokenValiditySeconds(300)
+            ?.accessTokenValiditySeconds(30)
     }
 
     override fun configure(endpoints: AuthorizationServerEndpointsConfigurer?) {

--- a/authentication/src/main/kotlin/com/sns/authentication/config/OAuth2Config.kt
+++ b/authentication/src/main/kotlin/com/sns/authentication/config/OAuth2Config.kt
@@ -5,9 +5,11 @@ import com.sns.authentication.LoginUserTokenEnhancer
 import javax.sql.DataSource
 import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.annotation.Value
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean
 import org.springframework.boot.autoconfigure.security.oauth2.resource.ResourceServerProperties
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
+import org.springframework.context.annotation.Profile
 import org.springframework.core.io.FileSystemResource
 import org.springframework.security.authentication.AuthenticationManager
 import org.springframework.security.crypto.password.PasswordEncoder
@@ -45,7 +47,7 @@ class OAuth2Config(
             ?.authorizedGrantTypes("authorization_code", "refresh_token")
             ?.scopes("read")
             ?.autoApprove(true)
-            ?.accessTokenValiditySeconds(30)
+            ?.accessTokenValiditySeconds(300)
     }
 
     override fun configure(endpoints: AuthorizationServerEndpointsConfigurer?) {
@@ -67,6 +69,15 @@ class OAuth2Config(
 @Configuration
 class OAuth2ConfigBean {
     @Bean
+    @Profile("test")
+    fun jwtAccessTokenConverterTest(): JwtAccessTokenConverter {
+        val accessTokenConverter = JwtAccessTokenConverter()
+        accessTokenConverter.setSigningKey("jwtKey")
+        return accessTokenConverter
+    }
+
+    @Bean
+    @ConditionalOnMissingBean
     fun jwtAccessTokenConverter(
         @Value("\${security.oauth2.resource.jwt.custom-jks-path}") keyPath: String,
         @Value("\${security.oauth2.resource.jwt.custom-jks-passwd}") passwd: String,

--- a/authentication/src/main/kotlin/com/sns/authentication/user/User.kt
+++ b/authentication/src/main/kotlin/com/sns/authentication/user/User.kt
@@ -1,12 +1,10 @@
 package com.sns.authentication.user
 
-import java.sql.ResultSet
 import javax.validation.constraints.Max
 import javax.validation.constraints.NotBlank
 import org.springframework.data.annotation.Id
 import org.springframework.data.annotation.Transient
 import org.springframework.data.domain.Persistable
-import org.springframework.jdbc.core.RowMapper
 
 data class User(
     @Id
@@ -28,33 +26,4 @@ data class User(
 
     override fun getId() = this.id
     override fun isNew() = new
-
-    companion object {
-        val MAPPER: RowMapper<User> = UserRowMapper()
-    }
-}
-
-// purpose enum 매핑이 안되서 수동으로 작성함. 확인필요.
-class UserRowMapper : RowMapper<User> {
-    override fun mapRow(rs: ResultSet, rowNum: Int): User? {
-        return User(
-            id = rs.getString("id"),
-            password = rs.getString("password"),
-            name = rs.getString("name"),
-        )
-    }
-}
-
-enum class Status {
-    CREATED,
-    ACTIVATED,
-    DELETED;
-}
-
-data class UserId(
-    // TODO 적용 예정.
-    private val id: String, // email
-) {
-    public fun getEmailAddress() = this.id
-    public fun getId() = this.id
 }

--- a/authentication/src/test/kotlin/com/sns/authentication/AuthenticationApplicationTests.kt
+++ b/authentication/src/test/kotlin/com/sns/authentication/AuthenticationApplicationTests.kt
@@ -1,10 +1,13 @@
 package com.sns.authentication
 
 import org.junit.jupiter.api.Test
+import org.slf4j.LoggerFactory
 import org.springframework.boot.test.context.SpringBootTest
 
 @SpringBootTest
 class AuthenticationApplicationTests {
+
+    val log = LoggerFactory.getLogger(this.javaClass)
 
     @Test
     fun contextLoads() {

--- a/authentication/src/test/resources/application.yml
+++ b/authentication/src/test/resources/application.yml
@@ -12,9 +12,14 @@ logging:
 spring:
   profiles:
     active: test
-  datasource:
+  user-datasource:
     driver-class-name: org.h2.Driver
-    url: jdbc:h2:mem:testdb;MODE=MYSQL;DB_CLOSE_DELAY=-1
+    jdbc-url: jdbc:h2:mem:testdb;MODE=MYSQL;DB_CLOSE_DELAY=-1
+    username: root
+    password: test
+  auth-datasource:
+    driver-class-name: org.h2.Driver
+    jdbc-url: jdbc:h2:mem:testdb;MODE=MYSQL;DB_CLOSE_DELAY=-1
     username: root
     password: test
   sql:
@@ -23,15 +28,3 @@ spring:
       schema-locations: classpath*:db/*/*schema.sql
       data-locations: classpath*:db/*/*data.sql
       continue-on-error: false
-  mail:
-    host: smtp.gmail.com
-    port: 587
-    username: "none"
-    password: "none"
-    properties:
-      mail:
-        smtp:
-          auth: true
-          starttls:
-            enable: true
-

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -6,6 +6,8 @@ plugins {
     kotlin("jvm") version "1.5.31"
     kotlin("plugin.spring") version "1.5.31"
     id("org.jlleitschuh.gradle.ktlint") version "10.2.0"
+    id("java-library")
+    id("java-test-fixtures")
 }
 
 allprojects {
@@ -74,6 +76,7 @@ project(":user-api") {
 
         runtimeOnly("com.h2database:h2")
         runtimeOnly("mysql:mysql-connector-java")
+        testImplementation(testFixtures(project(":submodules:commons")))
     }
 }
 
@@ -105,10 +108,15 @@ project(":submodules") {
 }
 
 project(":submodules:commons") {
+    apply(plugin = "java-library")
+    apply(plugin = "java-test-fixtures")
     dependencies {
         api("org.springframework.boot:spring-boot-starter-integration")
         implementation("org.springframework.boot:spring-boot-starter-oauth2-resource-server")
         implementation("org.springframework.security:spring-security-oauth2-jose")
+        // testFixtures
+        testFixturesImplementation("org.springframework.boot:spring-boot-starter-test")
+        testFixturesImplementation("org.springframework.security:spring-security-test")
     }
 
     tasks.getByName<org.springframework.boot.gradle.tasks.bundling.BootJar>("bootJar") {

--- a/front/src/main/kotlin/com/sns/front/controller/AuthExampleController.kt
+++ b/front/src/main/kotlin/com/sns/front/controller/AuthExampleController.kt
@@ -45,6 +45,7 @@ class AuthExampleController(
             .onStatus(HttpStatus::isError) { it.bodyToMono(String::class.java).map { r -> RuntimeException(r) } }
             .bodyToMono(String::class.java)
             .doOnError { log.error(it.message) }
-            .block() ?: "Hi ${user.name}, this is front"
+            .onErrorResume { Mono.empty<String>() }
+            .blockOptional().orElse(null) ?: "Hi ${user.name}, this is front"
     }
 }

--- a/submodules/commons/src/main/kotlin/com/sns/commons/config/ResourceServerSecurityConfig.kt
+++ b/submodules/commons/src/main/kotlin/com/sns/commons/config/ResourceServerSecurityConfig.kt
@@ -1,7 +1,9 @@
 package com.sns.commons.config
 
 import com.sns.commons.oauth.Role
+import javax.crypto.spec.SecretKeySpec
 import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Profile
 import org.springframework.security.config.Customizer
 import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder
 import org.springframework.security.config.annotation.method.configuration.EnableGlobalMethodSecurity
@@ -9,7 +11,9 @@ import org.springframework.security.config.annotation.web.builders.HttpSecurity
 import org.springframework.security.config.annotation.web.builders.WebSecurity
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity
 import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter
+import org.springframework.security.config.http.SessionCreationPolicy
 import org.springframework.security.oauth2.jwt.JwtDecoder
+import org.springframework.security.oauth2.jwt.NimbusJwtDecoder
 import org.springframework.web.cors.CorsConfiguration
 import org.springframework.web.cors.CorsConfigurationSource
 import org.springframework.web.cors.UrlBasedCorsConfigurationSource
@@ -17,15 +21,6 @@ import org.springframework.web.cors.UrlBasedCorsConfigurationSource
 @EnableWebSecurity
 @EnableGlobalMethodSecurity(securedEnabled = true)
 class ResourceServerSecurityConfig : WebSecurityConfigurerAdapter() {
-
-    val WHITE_LIST = arrayOf(
-        "/",
-        "/swagger-resources/**",
-        "/swagger-ui/**",
-        "/v3/api-docs/**",
-        "/webjars/**",
-        "/api/*/sign-up/**",
-    )
 
     override fun configure(auth: AuthenticationManagerBuilder?) {
         auth!!.inMemoryAuthentication()
@@ -42,6 +37,8 @@ class ResourceServerSecurityConfig : WebSecurityConfigurerAdapter() {
         http.oauth2ResourceServer()
             .jwt()
         http.headers().frameOptions().disable()
+            .and()
+            .sessionManagement().sessionCreationPolicy(SessionCreationPolicy.NEVER)
     }
 
     override fun configure(web: WebSecurity?) {
@@ -55,4 +52,8 @@ class ResourceServerSecurityConfig : WebSecurityConfigurerAdapter() {
         source.registerCorsConfiguration("/**", configuration)
         return source
     }
+
+    @Profile("test")
+    @Bean
+    fun jwtDecoder(): JwtDecoder = NimbusJwtDecoder.withSecretKey(SecretKeySpec("key".toByteArray(), "RSA256")).build()
 }

--- a/submodules/commons/src/main/kotlin/com/sns/commons/config/WebConfig.kt
+++ b/submodules/commons/src/main/kotlin/com/sns/commons/config/WebConfig.kt
@@ -1,17 +1,16 @@
 package com.sns.commons.config
 
 import com.sns.commons.resolver.LoginUserResolver
-import org.springframework.context.annotation.Bean
+import com.sns.commons.resolver.LoginUserResolvers
 import org.springframework.context.annotation.Configuration
+import org.springframework.context.annotation.Import
 import org.springframework.web.method.support.HandlerMethodArgumentResolver
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer
 
+@Import(LoginUserResolvers::class)
 @Configuration
-class WebConfig() : WebMvcConfigurer {
+class WebConfig(val loginUserResolver: LoginUserResolver) : WebMvcConfigurer {
     override fun addArgumentResolvers(resolvers: MutableList<HandlerMethodArgumentResolver>) {
-        resolvers.add(loginUserResolver())
+        resolvers.add(loginUserResolver)
     }
-
-    @Bean
-    fun loginUserResolver() = LoginUserResolver()
 }

--- a/submodules/commons/src/main/kotlin/com/sns/commons/oauth/LoginUser.kt
+++ b/submodules/commons/src/main/kotlin/com/sns/commons/oauth/LoginUser.kt
@@ -1,5 +1,7 @@
 package com.sns.commons.oauth
 
+import org.springframework.security.core.userdetails.User
+
 data class LoginUser(
     val id: String? = null,
     val name: String? = null,
@@ -14,6 +16,13 @@ data class LoginUser(
             clientId = map.getOrDefault("client_id", "") as String,
             scope = map.getOrDefault("scope", listOf<String>()) as List<String>,
             authorities = map.getOrDefault("authorities", listOf<String>()) as List<String>,
+        )
+
+        fun forTest(user: User) = LoginUser(
+            id = user.username,
+            name = user.username,
+            authorities = user.authorities.map { toString() },
+            scope = user.authorities.map { toString() },
         )
     }
 }

--- a/submodules/commons/src/main/kotlin/com/sns/commons/oauth/LoginUser.kt
+++ b/submodules/commons/src/main/kotlin/com/sns/commons/oauth/LoginUser.kt
@@ -10,7 +10,7 @@ data class LoginUser(
     companion object {
         fun from(map: Map<String, Any>): LoginUser = LoginUser(
             id = map.getOrDefault("user_id", "") as String,
-            name = map.getOrDefault("user_name", "") as String,
+            name = map.getOrDefault("user_nickname", "") as String,
             clientId = map.getOrDefault("client_id", "") as String,
             scope = map.getOrDefault("scope", listOf<String>()) as List<String>,
             authorities = map.getOrDefault("authorities", listOf<String>()) as List<String>,

--- a/submodules/commons/src/main/kotlin/com/sns/commons/resolver/LoginUserResolver.kt
+++ b/submodules/commons/src/main/kotlin/com/sns/commons/resolver/LoginUserResolver.kt
@@ -2,11 +2,15 @@ package com.sns.commons.resolver
 
 import com.sns.commons.annotation.IsLoginUser
 import com.sns.commons.oauth.LoginUser
-import com.sns.commons.utils.log
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Profile
 import org.springframework.core.MethodParameter
 import org.springframework.security.core.context.SecurityContextHolder
+import org.springframework.security.core.userdetails.User
 import org.springframework.security.core.userdetails.UsernameNotFoundException
 import org.springframework.security.oauth2.jwt.Jwt
+import org.springframework.stereotype.Component
 import org.springframework.web.bind.support.WebDataBinderFactory
 import org.springframework.web.context.request.NativeWebRequest
 import org.springframework.web.method.support.HandlerMethodArgumentResolver
@@ -19,18 +23,51 @@ import org.springframework.web.method.support.ModelAndViewContainer
  *     fun controllerMethod(loginUser : LoginUser)
  * <pre>
  */
-class LoginUserResolver : HandlerMethodArgumentResolver {
-    val log = this.log()
+interface LoginUserResolver : HandlerMethodArgumentResolver
 
+/**
+ * 한번에 import 하기 위함.
+ */
+@Component
+class LoginUserResolvers {
+    @Profile("test")
+    @Bean
+    fun testUerResolver() = TestLoginUserResolver()
+
+    @ConditionalOnMissingBean(LoginUserResolver::class)
+    @Bean
+    fun defaultUserResolver() = DefaultLoginUserResolver()
+}
+
+/**
+ * withMockUser 사용을 위한 테스트용 체크
+ */
+class TestLoginUserResolver : LoginUserResolver {
     override fun resolveArgument(
         parameter: MethodParameter,
         mavContainer: ModelAndViewContainer?,
         webRequest: NativeWebRequest,
         binderFactory: WebDataBinderFactory?
-    ): Any? {
+    ): LoginUser {
+        val principal = SecurityContextHolder.getContext().authentication.principal
+        if (principal is User) {
+            return LoginUser.forTest(principal)
+        }
+        throw UsernameNotFoundException("로그인 인증에 실패했습니다")
+    }
+
+    override fun supportsParameter(parameter: MethodParameter): Boolean = parameter.hasMethodAnnotation(IsLoginUser::class.java)
+}
+
+class DefaultLoginUserResolver : LoginUserResolver {
+    override fun resolveArgument(
+        parameter: MethodParameter,
+        mavContainer: ModelAndViewContainer?,
+        webRequest: NativeWebRequest,
+        binderFactory: WebDataBinderFactory?
+    ): LoginUser {
         val principal = SecurityContextHolder.getContext().authentication.principal
         if (principal is Jwt) {
-            log.error("claims : {}", principal.claims)
             return LoginUser.from(principal.claims)
         }
         throw UsernameNotFoundException("로그인 인증에 실패했습니다")

--- a/submodules/commons/src/main/kotlin/com/sns/commons/resolver/LoginUserResolver.kt
+++ b/submodules/commons/src/main/kotlin/com/sns/commons/resolver/LoginUserResolver.kt
@@ -10,7 +10,6 @@ import org.springframework.security.core.context.SecurityContextHolder
 import org.springframework.security.core.userdetails.User
 import org.springframework.security.core.userdetails.UsernameNotFoundException
 import org.springframework.security.oauth2.jwt.Jwt
-import org.springframework.stereotype.Component
 import org.springframework.web.bind.support.WebDataBinderFactory
 import org.springframework.web.context.request.NativeWebRequest
 import org.springframework.web.method.support.HandlerMethodArgumentResolver
@@ -28,7 +27,6 @@ interface LoginUserResolver : HandlerMethodArgumentResolver
 /**
  * 한번에 import 하기 위함.
  */
-@Component
 class LoginUserResolvers {
     @Profile("test")
     @Bean

--- a/submodules/commons/src/testFixtures/kotlin/security/WithLoginUser.kt
+++ b/submodules/commons/src/testFixtures/kotlin/security/WithLoginUser.kt
@@ -1,0 +1,9 @@
+package security
+
+import org.springframework.security.test.context.support.WithMockUser
+
+@Target(AnnotationTarget.FUNCTION)
+@Retention(AnnotationRetention.RUNTIME)
+@WithMockUser(username = "user@gmail.com", authorities = ["read"])
+annotation class WithLoginUser(
+)

--- a/user-api/src/test/kotlin/com/sns/user/endpoints/user/UserControllerTest.kt
+++ b/user-api/src/test/kotlin/com/sns/user/endpoints/user/UserControllerTest.kt
@@ -1,0 +1,45 @@
+package com.sns.user.endpoints.user
+
+import com.sns.user.component.user.application.UserQueryService
+import security.WithLoginUser
+import org.hamcrest.core.StringContains.containsString
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.boot.test.mock.mockito.MockBean
+import org.springframework.security.test.context.support.WithAnonymousUser
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.content
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
+
+@SpringBootTest
+@AutoConfigureMockMvc
+// @WebMvcTest(controllers = [UserController::class])       //EnableJdbcAuditing 관련 autoConfigure 제외 필요
+class UserControllerTest @Autowired constructor(
+) {
+    @MockBean
+    lateinit var userQueryService: UserQueryService
+
+    @Autowired
+    lateinit var mockMvc: MockMvc
+
+    @DisplayName("로그인 유저가 인증되면, 결과가 리턴되어야 한다.")
+    @WithLoginUser
+    @Test
+    internal fun checkLogin_1() {
+        mockMvc.perform(get("/api/v1/users/checkLogin"))
+            .andExpect(status().isOk)
+            .andExpect(content().string(containsString("user@gmail.com")))
+    }
+
+    @DisplayName("비로그인 유저이면 UnAuthorized 이어야한다.")
+    @WithAnonymousUser
+    @Test
+    internal fun checkLogin_2() {
+        mockMvc.perform(get("/api/v1/users/checkLogin"))
+            .andExpect(status().isUnauthorized)
+    }
+}


### PR DESCRIPTION
## auth서버에 refresh_token 활성화
  - jwt.user_name 값 user.id로 수정. 
      - refresh_token 인증 위해 auth서버  내부에서 토큰찾아낼때 user_name값 이용해서 조회하고있어서 수정했습니다. 
## testConfig 추가
  - `TestConfiguration` 사용하려다  매번 테스트에서 어노테이션 추가해줘야할것같아서 main 소스에 같이 작성했습니다.
  - 로그인 유저 테스트 참고 UserControllerTest.kt

---
## oauth2  참고했던 사이트
- [MSA 에서 인증](https://medium.com/spoontech/%EB%A7%88%EC%9D%B4%ED%81%AC%EB%A1%9C%EC%84%9C%EB%B9%84%EC%8A%A4-%EA%B5%AC%EC%A1%B0-msa-%EC%9D%98-%EC%9D%B8%EC%A6%9D-%EB%B0%8F-%EC%9D%B8%EA%B0%80-authorization-authentication-a595179ab88e)
- [Oauth2 인증과정](https://taes-k.github.io/2019/06/20/spring-msa-4/ ) 만 참고하시면 될것같습니다. spring-cloud , spring-security 가 예전버전이고?? 저희쪽은 `spring-boot..-oauth2-**-server` 로 dependency 설정되어있어서 설정은 달라요
- 설정값은 [공식문서랑](https://godekdls.github.io/Spring%20Security/oauth2/) [Baeldung](https://www.baeldung.com/spring-security-oauth-resource-server) 등등 구글링했습니당 [1](https://www.skyer9.pe.kr/wordpress/?p=2405)
- [요건](https://iris-seer-b95.notion.site/Spring-Security-09e1b58431884395841bf8a80a97ae0f) 정리된건 아니고 찾으면서 이것저것 적은건데 필요하시면 보시면 될것같아요!

resolve #31